### PR TITLE
Updated urls to https, and incremented version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For additional documentation, visit: http://myanimelist.net/modules.php?go=api
 
 Add this line to your application's Gemfile:
 
-    gem 'myanimelist', '~> 0.0.5'
+    gem 'myanimelist', '~> 0.0.6'
 
 And then execute:
 

--- a/lib/myanimelist/anime.rb
+++ b/lib/myanimelist/anime.rb
@@ -13,7 +13,7 @@ module MyAnimeList
     def get_search(name)
       response = RestClient::Request.new(
         method: :get,
-        url: "http://myanimelist.net/api/anime/search.xml?q=#{CGI::escape name}",
+        url: "https://myanimelist.net/api/anime/search.xml?q=#{CGI::escape name}",
         user: @myanimelist_username,
         password: @myanimelist_password,
         content_type: :xml ).execute

--- a/lib/myanimelist/manga.rb
+++ b/lib/myanimelist/manga.rb
@@ -13,7 +13,7 @@ module MyAnimeList
     def get_search(name)
       response = RestClient::Request.new(
         method: :get,
-        url: "http://myanimelist.net/api/manga/search.xml?q=#{CGI::escape name}",
+        url: "https://myanimelist.net/api/manga/search.xml?q=#{CGI::escape name}",
         user: @myanimelist_username,
         password: @myanimelist_password,
         content_type: :xml ).execute

--- a/lib/myanimelist/version.rb
+++ b/lib/myanimelist/version.rb
@@ -1,3 +1,3 @@
 module Myanimelist
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end


### PR DESCRIPTION
This fixes the 404 error you get when trying to access the old non https api urls.